### PR TITLE
user association complete

### DIFF
--- a/odins_spear/methods/get.py
+++ b/odins_spear/methods/get.py
@@ -57,16 +57,22 @@ class Get():
 #CALL CAPACITY
 #CALL CENTER
 
-    def group_call_centers(self, service_provider_id, group_id):
+    def group_call_centers(self, service_provider_id: str, group_id: str):
 
         endpoint = f"/groups/call-centers?serviceProviderId={service_provider_id}&groupId={group_id}"
         
         return self.requester.get(endpoint)
 
 
-    def group_call_center(self, service_user_id):
+    def group_call_center(self, service_user_id: str):
 
         endpoint = f"/groups/call-centers?serviceUserId={service_user_id}"
+        
+        return self.requester.get(endpoint)
+    
+    def user_call_center(self, user_id: str):
+
+        endpoint = f"/users/call-center?userId={user_id}"
         
         return self.requester.get(endpoint)
     
@@ -81,6 +87,13 @@ class Get():
 #CALL NOTIFY
 #CALL PARK
 #CALL PICKUP
+
+    def call_pickup_group_user(self, service_provider_id, group_id, user_id):
+
+        endpoint = f"/groups/call-pickup/user?serviceProviderId={service_provider_id}&groupId={group_id}&userId={user_id}"
+        
+        return self.requester.get(endpoint)
+
 #CALL POLICIES
 #CALL PROCESSING POLICIES
 #CALL RECORDING
@@ -145,6 +158,14 @@ class Get():
         endpoint = f"/groups/hunt-groups?serviceUserId={service_user_id}"
             
         return self.requester.get(endpoint)
+    
+    
+    def group_hunt_group_user(self, service_provider_id, group_id, user_id):
+    
+        endpoint = f"/groups/hunt-groups/user?serviceProviderId={service_provider_id}&groupId={group_id}&userId={user_id}"
+            
+        return self.requester.get(endpoint)
+    
 
 #IN CALL SERVICE ACTIVATION
 #INSTANT GROUP CALL
@@ -183,7 +204,7 @@ class Get():
 #REMOTE OFFICE
 #REPORTS
 
-    def user_report(self, user_id):
+    def user_report(self, user_id: str):
         """ Detailed report of user including services and service packs assigned.
 
         Args:

--- a/odins_spear/scripter.py
+++ b/odins_spear/scripter.py
@@ -43,3 +43,6 @@ class Scripter:
     
     def user_huntgroup_membership(self, user):
         return scripts.user_huntgroup_membership.main(self.api, user)
+
+    def user_association(self, service_provider_id: str, group_id: str, user_id: str):
+        return scripts.user_association.main(self.api, service_provider_id, group_id, user_id)

--- a/odins_spear/scripts/__init__.py
+++ b/odins_spear/scripts/__init__.py
@@ -4,7 +4,8 @@ __all__ = [
     "find_alias",
     "group_audit",
     "user_activity",
-    "user_huntgroup_membership"
+    "user_huntgroup_membership",
+    "user_association"
 ]
 
 from .bulk_enable_voicemail import main
@@ -13,3 +14,4 @@ from .find_alias import main
 from .group_audit import main
 from .user_activity import main
 from .user_huntgroup_membership import main
+from .user_association import main

--- a/odins_spear/scripts/find_alias.py
+++ b/odins_spear/scripts/find_alias.py
@@ -1,8 +1,6 @@
 import re
-import time
 from tqdm import tqdm
 
-from odins_spear.exceptions import AOAliasNotFound
 import odins_spear.logger as logger
 
 def locate_alias(alias, aliases: list):

--- a/odins_spear/scripts/user_association.py
+++ b/odins_spear/scripts/user_association.py
@@ -1,0 +1,55 @@
+from tqdm import tqdm
+
+import odins_spear.logger as logger
+
+def main(api, service_provider_id: str, group_id: str, user_id: str):
+    """ Identifies all huntgroups a user is associated to and returns a list.
+    if no huntgroup associacted None is returned.
+    
+    :param x:
+    :param y:
+    :param z:
+
+    :return r:
+    """
+    
+    USER_DATA = {
+        "user_id": user_id,
+        "first_name": None,
+        "last_name": None,
+        "extension": None,
+        "phone_number": None,
+        "services": None,
+        "feature_packs": None,
+        "hunt_groups": [],
+        "call_centers": [],
+        "pick_up_group": None
+    }
+    
+    user = api.get.user_report(user_id)
+    USER_DATA["first_name"] = user["firstName"]
+    USER_DATA["last_name"] = user["lastName"]
+    USER_DATA["extension"] = user["extension"]
+    USER_DATA["phone_number"] = user["phoneNumber"]
+    USER_DATA["services"] = user["userServices"]
+    USER_DATA["feature_packs"] = user["servicePacks"]
+    
+    
+    pick_up_group = api.get.call_pickup_group_user(service_provider_id, group_id, user_id)
+    USER_DATA["pick_up_group"] = pick_up_group[0]["name"]
+    
+    hunt_groups = api.get.group_hunt_group_user(service_provider_id, group_id, user_id)
+    for hg in hunt_groups:
+        USER_DATA["hunt_groups"].append(hg["serviceUserId"])
+    
+    call_centers = api.get.user_call_center(user_id)
+    for cc in call_centers["callCenters"]:
+        USER_DATA["call_centers"].append(cc["serviceUserId"])
+        
+    print("User Data:")
+    for key, value in USER_DATA.items():
+        if isinstance(value, list):
+            value = ', '.join(map(str, value))
+        elif value is None:
+            value = "N/A"
+        print(f"\t{key.replace('_', ' ').title()}: {value}")


### PR DESCRIPTION
This script is to identify a user's associations with Call Centers (CC), Hunt Groups (HG), and Pick Up Groups. Additionally, this returns other key information of the user such as extension, phone number, and services and feature packs assigned as this data can be useful when reviewing which CC and HG they are associated to for example if an agent in a CC has a higher feature pack than needed for work in x CC.