### PR TITLE
service pack audit complete

### DIFF
--- a/odins_spear/scripter.py
+++ b/odins_spear/scripter.py
@@ -16,13 +16,16 @@ class Scripter:
     def __init__(self, api) -> None:
         self.api = api
 
+
     # TODO: How will users be passed in
     def bulk_enable_voicemail(self, users):
         return scripts.bulk_enable_voicemail.main(self.api, users)
 
+
     # TODO: How will users be passed in
     def bulk_password_reset(self, users):
         return scripts.bulk_password_reset.main(self.api, users)
+
 
     def find_alias(self, service_provider_id: str, group_id: str, alias: str):
         """ Locates alias if assigned to broadworks entity. 
@@ -37,6 +40,7 @@ class Scripter:
         return scripts.find_alias.main(self.api, service_provider_id, group_id,
                                        alias)
 
+
     def group_audit(self, service_provider_id: str, group_id: str):
         """
         Produces a report of key information within the group.
@@ -49,11 +53,28 @@ class Scripter:
         """
         return scripts.group_audit.main(self.api, service_provider_id, group_id)
 
+
+    def service_pack_audit(self, servive_provider_id, group_id):
+        """
+        A stripped down version of group audit focussing only on the service packs assigned within
+        the group. This only shows the service packs assigned and total count of unlike group audit 
+        which details the users this is assigned to.
+
+        :param service_provider_id (str): Service Provider ID or Enterprise ID containing the Group ID.
+        :param group_id (str): Group ID to generate the report for.
+
+        :return str: A JSON formatted report of service packs assigend in the group.
+        """
+        return scripts.service_pack_audit.main(self.api, servive_provider_id, group_id)
+
+
     def user_activity(self, user):
         return scripts.user_activity.main(self.api, user)
 
+
     def user_association(self, service_provider_id: str, group_id: str, user_id: str):
-        """ identify a user's associations with Call Centers (CC), Hunt Groups (HG), 
+        """ 
+        identify a user's associations with Call Centers (CC), Hunt Groups (HG), 
         and Pick Up Groups.
 
         :pararm service_provider_id (str): Service Provider where the group is hosted.

--- a/odins_spear/scripts/__init__.py
+++ b/odins_spear/scripts/__init__.py
@@ -3,8 +3,8 @@ __all__ = [
     "bulk_password_reset",
     "find_alias",
     "group_audit",
+    "service_pack_audit",
     "user_activity",
-    "user_huntgroup_membership",
     "user_association"
 ]
 
@@ -12,6 +12,6 @@ from .bulk_enable_voicemail import main
 from .bulk_password_reset import main
 from .find_alias import main
 from .group_audit import main
+from .service_pack_audit import main
 from .user_activity import main
-from .user_huntgroup_membership import main
 from .user_association import main

--- a/odins_spear/scripts/service_pack_audit.py
+++ b/odins_spear/scripts/service_pack_audit.py
@@ -1,0 +1,34 @@
+import json
+from tqdm import tqdm
+
+def main(api, service_provider_id, group_id):
+    """
+        A stripped down version of group audit focussing only on the service packs assigned within
+        the group. This only shows the service packs assigned and total count of unlike group audit 
+        which details the users this is assigned to.
+
+        :param service_provider_id (str): Service Provider ID or Enterprise ID containing the Group ID.
+        :param group_id (str): Group ID to generate the report for.
+
+        :return str: A JSON formatted report of service packs assigend in the group.
+    """    
+    
+    service_report = api.get.group_services(group_id, service_provider_id)
+
+    assigned_service_pack_services = []
+
+    for sps in tqdm(service_report["servicePackServices"], desc="Analysing Service Packs..."):
+            if sps["usage"] > 0:
+                del sps["authorized"]
+                del sps["assigned"]
+                del sps["limited"]
+                del sps["allowed"]
+                del sps["serviceName"]
+                del sps["quantity"]
+                del sps["alias"]
+
+                assigned_service_pack_services.append(sps)
+                
+    return json.dumps({
+        "service_pack_services": assigned_service_pack_services
+})


### PR DESCRIPTION
 A stripped down version of group audit focussing only on the service packs assigned within the group. This only shows the service packs assigned and total count of unlike group audit which details the users this is assigned to.