### PR TITLE
Add API exception

### DIFF
--- a/odins_spear/exceptions.py
+++ b/odins_spear/exceptions.py
@@ -130,11 +130,13 @@ class OSFileNotFound(OSError):
 
     def __str__(self) -> str:
         return f"File can not be found, please check path and file name."   
-
-
-class OSLicenseNonExistent(OSError):
-    """ Raised when the Specified Entity doesn't exist due to licensing.  
+    
+class OSApiResponseError(OSError):
+    """ Raised when Odin Api returns an error code.
     """
+    def __init__(self, response):
+        response = response.json()
+        self.response = f"{response['details']} {response['status']}: {response['error']}"
 
     def __str__(self) -> str:
-        return f"Specified Entity doesn't have the correct License." 
+        return self.response

--- a/odins_spear/methods/get.py
+++ b/odins_spear/methods/get.py
@@ -156,13 +156,9 @@ class Get():
         params = {
             "userId": user_id
         }
-        try:
-            import requests.exceptions
-            response = self.requester.get(endpoint, params=params)
-        except requests.exceptions.RequestException:
-            raise OSLicenseNonExistent
-        else:
-            return response
+        
+        return self.requester.get(endpoint, params=params)
+        
     
     
     def group_call_center_bounced_calls(self, service_user_id: str):

--- a/odins_spear/requester.py
+++ b/odins_spear/requester.py
@@ -1,5 +1,6 @@
 import requests
 import json
+from . import exceptions
 
 from ratelimit import limits, sleep_and_retry
 class Requester():
@@ -92,6 +93,12 @@ class Requester():
             self.logger._log_request(endpoint=endpoint, response_code=response.status_code)
         
         # flags errors if any returned from the API
-        response.raise_for_status()
-        return response.json()
+        try:
+            response.raise_for_status()
+        except requests.exceptions.RequestException:
+            raise exceptions.OSApiResponseError(response)
+        else:
+            return response.json()
+        
+
     

--- a/odins_spear/requester.py
+++ b/odins_spear/requester.py
@@ -1,6 +1,6 @@
 import requests
 import json
-from . import exceptions
+from .exceptions import OSApiResponseError
 
 from ratelimit import limits, sleep_and_retry
 class Requester():
@@ -71,8 +71,12 @@ class Requester():
                 self.logger._log_request(endpoint=endpoint, response_code=response.status_code)
                 
             # flags errors if any returned from the API
-            response.raise_for_status()
-            return response.json()
+            try:
+                response.raise_for_status()
+            except requests.exceptions.RequestException:
+                raise OSApiResponseError(response)
+            else:
+                return response.json()
         
 
     @sleep_and_retry
@@ -96,7 +100,7 @@ class Requester():
         try:
             response.raise_for_status()
         except requests.exceptions.RequestException:
-            raise exceptions.OSApiResponseError(response)
+            raise OSApiResponseError(response)
         else:
             return response.json()
         


### PR DESCRIPTION
Added the API exception alongside cleaned up a few area that have been made redundant

This allows for more descriptive error handling when a request exception occurs

Previous:

```python
requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: https://api.api.com/api/v2/users/call-center?userId=userID@userID.com
```

New:
```python
odins_spear.exceptions.OSApiResponseError: ODIN API Error 400: [Error 4410] Service is not assigned to this subscriber: Call Center - Basic
```